### PR TITLE
Bump dependencies version in CI workflow

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -14,7 +14,7 @@ jobs:
     name: 'Build documentation on Linux'
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |
@@ -27,7 +27,7 @@ jobs:
         make html
 
     - name: Deploy to GitHub Pages
-      uses: crazy-max/ghaction-github-pages@v2
+      uses: crazy-max/ghaction-github-pages@v4
       with:
         target_branch: gh-pages
         build_dir: Documentation/_build/html


### PR DESCRIPTION
This pull request updates the dependency versions in the GitHub Actions CI workflow to ensure that we are using the latest stable releases. Specifically, the version of the `actions/checkout` action has been bumped from v2 to v4, and the `crazy-max/ghaction-github-pages` action has been updated from v2 to v4. These changes help maintain compatibility with the latest features and security updates.

---

> This pull request was co-created with Cosine Genie

Original Task: [iverilog/4mwjco5so3o9](https://cosine.wtf/neocortex/iverilog/task/4mwjco5so3o9)
Author: Alistair Pullen
