### PR TITLE
Add Graphviz DOT Output for Design Hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,15 @@ optimized netlist by using the `-N <path>` flag to the compiler. If
 elaboration succeeds, the final netlist (i.e., after optimizations but
 before code generation) will be dumped into the file named `<path>`.
 
+Additionally, you can generate a Graphviz DOT diagram of the elaborated
+design hierarchy using the `-G <path>` flag to the `ivl` subcommand. The
+resulting DOT file can be rendered with Graphviz, for example:
+
+```
+ivl -G design.dot <other ivl options...>
+dot -Tsvg design.dot -o design.svg
+```
+
 Elaboration is performed in two steps: scopes and parameters
 first, followed by the structural and behavioural elaboration.
 

--- a/design_dump.cc
+++ b/design_dump.cc
@@ -25,6 +25,7 @@
 # include  <typeinfo>
 # include  <iostream>
 # include  <iomanip>
+# include  <sstream>
 # include  "netlist.h"
 # include  "compiler.h"
 # include  "discipline.h"
@@ -37,6 +38,94 @@
 # include  "PExpr.h"
 
 using namespace std;
+
+/* Helpers for DOT output */
+static std::string dot_escape(const std::string& s)
+{
+      std::string r;
+      r.reserve(s.size());
+      for (size_t i = 0; i < s.size(); ++i) {
+            const char c = s[i];
+            switch (c) {
+              case '"':  r += "\\\""; break;
+              case '\\': r += "\\\\"; break;
+              case '\n': r += "\\n";  break;
+              case '\r': /* ignore CR */ break;
+              case '\t': r += "\\t";  break;
+              default:   r += c;      break;
+            }
+      }
+      return r;
+}
+
+static std::string dot_id(const void* p)
+{
+      std::ostringstream oss;
+      oss << "n" << p;
+      return oss.str();
+}
+
+/* Dump the design hierarchy (Graphviz DOT) */
+void Design::dump_hierarchy_dot(std::ostream& o) const
+{
+      o << "digraph ivl_hierarchy {\n";
+      o << "  graph [rankdir=LR];\n";
+      o << "  node  [shape=box, fontname=\"Helvetica\", fontsize=10];\n";
+      o << "  edge  [fontname=\"Helvetica\", fontsize=9, color=\"#555555\"];\n";
+
+      /* Root scopes (top-level modules) */
+      for (std::list<NetScope*>::const_iterator it = root_scopes_.begin();
+           it != root_scopes_.end(); ++it) {
+            if (*it) (*it)->dump_hierarchy_dot(o);
+      }
+
+      /* Also include packages as separate trees */
+      for (std::map<perm_string,NetScope*>::const_iterator pk = packages_.begin();
+           pk != packages_.end(); ++pk) {
+            if (pk->second) pk->second->dump_hierarchy_dot(o);
+      }
+
+      o << "}\n";
+}
+
+/* Dump a NetScope and its children as DOT nodes/edges */
+void NetScope::dump_hierarchy_dot(std::ostream& o) const
+{
+      const std::string id = dot_id(this);
+
+      const char* base_c = basename();
+      std::string base = base_c ? std::string(base_c) : std::string("");
+
+      const char* mod_c = module_name();
+      std::string mod = mod_c ? std::string(mod_c) : std::string("");
+
+      std::string label = base.empty() ? std::string("<anonymous>") : base;
+      if (!mod.empty()) {
+            label += " [";
+            label += mod;
+            label += "]";
+      }
+
+      std::ostringstream tip;
+      tip << scope_path(this);
+      std::string fileline = get_fileline();
+      if (!fileline.empty()) {
+            tip << " (" << fileline << ")";
+      }
+
+      o << "  \"" << id << "\""
+        << " [label=\""   << dot_escape(label)   << "\""
+        << ", tooltip=\"" << dot_escape(tip.str()) << "\""
+        << "];\n";
+
+      for (std::map<hname_t,NetScope*>::const_iterator cur = children_.begin();
+           cur != children_.end(); ++cur) {
+            const NetScope* child = cur->second;
+            if (!child) continue;
+            child->dump_hierarchy_dot(o);
+            o << "  \"" << id << "\" -> \"" << dot_id(child) << "\";\n";
+      }
+}
 
 static ostream& operator<< (ostream&o, NetBlock::Type t)
 {

--- a/main.cc
+++ b/main.cc
@@ -915,6 +915,7 @@ int main(int argc, char*argv[])
 
       const char* net_path = 0;
       const char* pf_path = 0;
+      const char* dot_path = 0;
       int opt;
 
       struct tms cycles[5];
@@ -939,7 +940,7 @@ int main(int argc, char*argv[])
       min_typ_max_flag = TYP;
       min_typ_max_warn = 10;
 
-      while ((opt = getopt(argc, argv, "C:F:f:hN:P:p:Vv")) != EOF) switch (opt) {
+      while ((opt = getopt(argc, argv, "C:F:f:hN:P:G:p:Vv")) != EOF) switch (opt) {
 
 	  case 'C':
 	    read_iconfig_file(optarg);
@@ -954,14 +955,17 @@ int main(int argc, char*argv[])
 	    help_flag = true;
 	    break;
 	  case 'N':
-	    net_path = optarg;
-	    break;
-	  case 'P':
-	    pf_path = optarg;
-	    break;
-	  case 'p':
-	    parm_to_flagmap(optarg);
-	    break;
+        net_path = optarg;
+        break;
+      case 'P':
+        pf_path = optarg;
+        break;
+      case 'G':
+        dot_path = optarg;
+        break;
+      case 'p':
+        parm_to_flagmap(optarg);
+        break;
 	  case 'v':
 	    verbose_flag = true;
 #          if defined(HAVE_TIMES)
@@ -1003,6 +1007,7 @@ int main(int argc, char*argv[])
 "\t-h               Print usage information, and exit.\n"
 "\t-N <file>        Dump the elaborated netlist to <file>.\n"
 "\t-P <file>        Write the parsed input to <file>.\n"
+"\t-G <file>        Dump the elaborated hierarchy (Graphviz DOT) to <file>.\n"
 "\t-p <assign>      Set a parameter value.\n"
 "\t-v               Print progress indications"
 #if defined(HAVE_TIMES)
@@ -1308,10 +1313,17 @@ int main(int argc, char*argv[])
 
       if (net_path) {
 	    if (verbose_flag)
-		  cerr<<" dumping netlist to " <<net_path<< "..." <<endl;
+		  cerr<<" dumping netlist to " <<net_path<< "...\" <<endl;
 
 	    ofstream out (net_path);
 	    des->dump(out);
+      }
+
+      if (dot_path) {
+            if (verbose_flag)
+                  cerr << " dumping hierarchy (DOT) to " << dot_path << "..." << endl;
+            ofstream dout(dot_path);
+            des->dump_hierarchy_dot(dout);
       }
 
       if (des->errors) {

--- a/netlist.h
+++ b/netlist.h
@@ -1194,6 +1194,7 @@ class NetScope : public Definitions, public Attrib {
       perm_string local_symbol();
 
       void dump(std::ostream&) const;
+      void dump_hierarchy_dot(std::ostream&) const;
 	// Check to see if the scope has items that are not allowed
 	// in an always_comb/ff/latch process.
       virtual bool check_synth(ivl_process_type_t pr_type, const NetScope*scope) const;
@@ -5176,6 +5177,7 @@ class Design {
 
 	// Iterate over the design...
       void dump(std::ostream&) const;
+      void dump_hierarchy_dot(std::ostream&) const;
       void functor(struct functor_t*);
       void join_islands(void);
       int emit(struct target_t*) const;


### PR DESCRIPTION
This pull request introduces a new feature that allows users to generate a Graphviz DOT diagram representing the elaborated design hierarchy. This is accomplished by adding a `-G <path>` option to the `ivl` command, enabling the output of a DOT file, which can then be rendered using Graphviz. Notable changes include modifications to `main.cc`, `design_dump.cc`, and `netlist.h`, with functions added to facilitate the dumping of the design hierarchy in DOT format. This feature enhances visualization and debugging capabilities of the design structure.

---

> This pull request was co-created with Cosine Genie

Original Task: [iverilog/lsdv02s87p2m](https://cosine.wtf/neocortex/iverilog/task/lsdv02s87p2m)
Author: Alistair Pullen
